### PR TITLE
Fix background color to black

### DIFF
--- a/api2.html
+++ b/api2.html
@@ -16,7 +16,7 @@
             --warning: #ff9e00;
             --success: #00ff88;
             --dark: #0a0a16;
-            --darker: #050510;
+            --darker: #000000;
             --glass: rgba(255, 255, 255, 0.05);
             --glass-border: rgba(255, 255, 255, 0.1);
             --glow-primary: 0 0 15px var(--primary), 0 0 30px var(--primary);
@@ -32,15 +32,12 @@
         }
         
         body {
-            background-color: var(--darker);
+            background-color: #000000;
             color: #e0e0ff;
             font-family: 'Exo 2', sans-serif;
             line-height: 1.6;
             overflow-x: hidden;
-            background-image: 
-                radial-gradient(circle at 10% 20%, rgba(157, 78, 221, 0.05) 0%, transparent 20%),
-                radial-gradient(circle at 90% 80%, rgba(0, 243, 255, 0.05) 0%, transparent 20%),
-                radial-gradient(circle at 50% 50%, rgba(255, 0, 200, 0.03) 0%, transparent 30%);
+            background-image: none;
             min-height: 100vh;
             position: relative;
         }
@@ -52,9 +49,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background-image: 
-                linear-gradient(rgba(0, 243, 255, 0.1) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(0, 243, 255, 0.1) 1px, transparent 1px);
+            background-image: none;
             background-size: 50px 50px;
             z-index: -1;
             opacity: 0.3;

--- a/deepseek_html_20251001_74e341.html
+++ b/deepseek_html_20251001_74e341.html
@@ -16,7 +16,7 @@
             --warning: #ff9e00;
             --success: #00ff88;
             --dark: #0a0a16;
-            --darker: #050510;
+            --darker: #000000;
             --glass: rgba(255, 255, 255, 0.05);
             --glass-border: rgba(255, 255, 255, 0.1);
             --glow-primary: 0 0 15px var(--primary), 0 0 30px var(--primary);
@@ -32,15 +32,12 @@
         }
         
         body {
-            background-color: var(--darker);
+            background-color: #000000;
             color: #e0e0ff;
             font-family: 'Exo 2', sans-serif;
             line-height: 1.6;
             overflow-x: hidden;
-            background-image: 
-                radial-gradient(circle at 10% 20%, rgba(157, 78, 221, 0.05) 0%, transparent 20%),
-                radial-gradient(circle at 90% 80%, rgba(0, 243, 255, 0.05) 0%, transparent 20%),
-                radial-gradient(circle at 50% 50%, rgba(255, 0, 200, 0.03) 0%, transparent 30%);
+            background-image: none;
             min-height: 100vh;
             position: relative;
         }
@@ -52,9 +49,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background-image: 
-                linear-gradient(rgba(0, 243, 255, 0.1) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(0, 243, 255, 0.1) 1px, transparent 1px);
+            background-image: none;
             background-size: 50px 50px;
             z-index: -1;
             opacity: 0.3;


### PR DESCRIPTION
Set the global background color to pure black by updating theme variables and removing all decorative background images.

The user reported that the background was not truly black. This PR addresses the issue by changing the `--darker` CSS variable to `#000000`, explicitly setting `body { background-color: #000000; background-image: none; }`, and removing background images from the `.hologram-grid` to ensure a pure black background across the page.

---
<a href="https://cursor.com/background-agent?bcId=bc-0859443b-e18a-4655-9de6-ff5b983039f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0859443b-e18a-4655-9de6-ff5b983039f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

